### PR TITLE
Cleanup, 2 noticeable changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.12.1-slim-bookworm
-RUN useradd --create-home --shell /bin/bash appuser
+RUN useradd --create-home --shell /bin/sh appuser
 WORKDIR /home/appuser/app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 USER appuser
 COPY . .
-CMD ["bash", "run.sh"]
+CMD run.sh

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 set -a
 source .env
 set +a
 
-python ./main.py \
+exec python ./main.py \
     --db-host="${DB_HOST}" \
     --db-port="${DB_PORT}" \
     --db-user="${DB_USER}" \


### PR DESCRIPTION
* Use `.2f` formatting to avoid trailing digits in alerts
* Use sh over bash, which on debian is dash